### PR TITLE
There is no "star 86"

### DIFF
--- a/script/flight-director-loop.txt
+++ b/script/flight-director-loop.txt
@@ -11208,6 +11208,7 @@ Have you got anything on confirming the attitude?
 
 [61 21 40 - 61 21 43] GUIDO
 Negative, FLIGHT. The only star available is star 86, there.
+> The star list only went up to 50, including Sun, Earth, and Moon. This is likely be a tongue-in-cheek reference to something else.
 
 [61 21 47 - 61 21 48] GUIDO
 FLIGHT, MIT will not have a run on this thing.


### PR DESCRIPTION
GUIDO refers to star 86 but there was no such thing. The list only went up to 50, including Sun, Earth, and Moon.
It might refer to "dead reckoning", as NOUN 86 would hold a Delta V vector;
Or it might refer to VERB 86 which would reject a mark taken on the backup optics; however, that was in the lunar rendezvous routine.