### PR TITLE
Update flight-director-loop.txt

### DIFF
--- a/script/flight-director-loop.txt
+++ b/script/flight-director-loop.txt
@@ -2407,6 +2407,9 @@ Go.
 [57 05 12] GNC
 He has it on, FLIGHT.
 
+[57 05 27 - 57 05 28] INCO
+We still don't have OMNI Charlie, FLIGHT.
+
 [57 05 31 - 57 05 32] CAPCOM
 I never got a call for OMNI Charlie, you want it?
 


### PR DESCRIPTION
At 57:05:27, INCO says "We still don't have OMNI Charlie, FLIGHT" but this is not in the transcript.
Added it according to the existing format. Not sure if other files need to be edited, this is my first contribution.