### PR TITLE
Update flight-director-loop.txt - added off loop remark

### DIFF
--- a/script/flight-director-loop.txt
+++ b/script/flight-director-loop.txt
@@ -12401,6 +12401,9 @@ Okay.
 [- 61 52 24] FLIGHT
 - I'd like, quickly, to know what you want done.
 
+[61 52 36] INCO (off loop)
+Okay, CAPCOM, you should have the LM back.
+
 [61 52 41] INCO
 FLIGHT, INCO.
 


### PR DESCRIPTION
Before INCO announces on the loop that contact has been re-established after the 5 minute (which ended up being about 7 minutes) transceiver power-off, someone (possibly INCO or Gold INCO? I recognize the voice) says off-loop to CAPCOM that they have the LM uplink back for comm.
The voice sounds a bit too nasally to be the INCO we've been hearing, but I'm not sure who else would have said this to CAPCOM -- maybe NETWORK?